### PR TITLE
Corrected Niko's pronouns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Desktop Niko
-Niko is a playable character from the game OneShot, but now he will be right on your screen!
+Niko is a playable character from the game OneShot, but now they will be right on your screen!
 The Steam version of the 2024 "The World Machine Edition" was used as the basis, as can be seen in the application settings.
 
 ## Features
@@ -15,7 +15,7 @@ The Steam version of the 2024 "The World Machine Edition" was used as the basis,
 ## Plans for futere
 - Make more facepicks variants, maybe accesories support
 - Maybe some idle animations
-- I'd like to make some games related to Niko and his love of pancakes, but I'm not sure if it's necessary.
+- I'd like to make some games related to Niko and their love of pancakes, but I'm not sure if it's necessary.
 
 # Editing and Compiling
 To create and export the project, I used Godot Engine Mono 4.4.1 to simplify creation and expansion, I did not use any additional plugins, so in theory it should be easy to compile.

--- a/translations.csv
+++ b/translations.csv
@@ -130,7 +130,7 @@ DATA_RESET_POPUP_MESSAGE,"Are you sure you want to completely reset all data?\nT
 SAVE,Save,Сохранить,Зберігши,
 PRESS_F_TO_FLIP_NIKO,Press [F] to flip Niko!,Нажми [F] что повернуть Нико!,,"Натисніть [F] що повернути Ніко!"
 DO_EVENTS_HINT,Determines whether to show events during clicks.,"Определяет, показывать ли события во время кликов.",,"Визначає, чи показувати події під час кліків."
-NIKO_ALWAYS_ON_TOP_HINT,"Niko will always be on top of windows. If he/she will not be visible in a game, then set FRAMELESS fullscreen mode.","Нико будет всегда поверх окон. Если в игре его(её) не будет видно, то поставьте БЕЗРАМОЧНЫЙ полноэкранный режим.",,"Ніко буде завжди поверх вікон. Якщо в грі його(її) не буде видно, то поставте БЕЗРАМКОВИЙ повноекранний режим."
+NIKO_ALWAYS_ON_TOP_HINT,"Niko will always be on top of windows. If they will not be visible in a game, then set FRAMELESS fullscreen mode.","Нико будет всегда поверх окон. Если в игре его(её) не будет видно, то поставьте БЕЗРАМОЧНЫЙ полноэкранный режим.",,"Ніко буде завжди поверх вікон. Якщо в грі його(її) не буде видно, то поставте БЕЗРАМКОВИЙ повноекранний режим."
 WINDOWS_ALWAYS_ON_TOP_HINT,"Program's windows will always be on top of other windows.",Окна программы будут всегда поверх других окон.,,
 TAKSBAR_ICON_HINT,"Determines whether to show application icon in taskbar. Does not apply to other program's windows","Определяет, показывать иконку приложения в панели задач. Не распространяется на другие окна программы",,"Визначає, показувати іконку програми в панелі завдань. Не поширюється на інші вікна програми"
 SNAP_TO_BOTTOM,Snap to bottom,Крепить к низу,,Кріпити до низу


### PR DESCRIPTION
Niko is canonically [ambiguous gender, according to Eliza Velasquez](https://elizavq.tumblr.com/post/113737817876/hello-i-really-like-this-game-but-one-question-i), and [Nightmargin has stated to not know Niko's gender](https://nightmargin.tumblr.com/post/140577597251/what-is-nikos-gender-if-they-have-one-i-heard). The [trailer for World Machine Edition](https://www.youtube.com/watch?v=8PaAA0GkSv4&t=41s), as well as [Niko's bio in WME](https://oneshot.fandom.com/wiki/Niko#World_Machine_Edition) (spoilers), uses they/them. So using he or she would be inaccurate.

The description for the repo on GitHub says "don't upset his", but I am unable to change this to "don't upset them". Additionally, I only know English, so I have not touched the other languages if they may need correcting.

No hostility behind this, you've made a great program which I immediately sent to others :D